### PR TITLE
Make shell and menu bar controls feel more native

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -141,7 +141,7 @@ private struct SidebarView: View {
         VStack(alignment: .leading, spacing: 18) {
             sidebarHeader
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 6) {
                 SidebarSectionTitle("Workspace")
 
                 ForEach(AppModel.SidebarItem.allCases) { item in
@@ -226,10 +226,10 @@ private struct SidebarView: View {
                                 endPoint: .bottomTrailing
                             )
                         )
-                        .frame(width: 46, height: 46)
+                        .frame(width: 42, height: 42)
 
                     Image(systemName: "waveform")
-                        .font(.system(size: 18, weight: .semibold))
+                        .font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(.white)
                 }
 
@@ -252,12 +252,12 @@ private struct SidebarView: View {
                     StatusDot(color: .green)
                 }
 
-                Text(appModel.isDictating ? "Listening" : "Ready for capture")
-                    .font(.subheadline.weight(.medium))
+                Text(appModel.isDictating ? "Listening" : "Ready")
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(appModel.isDictating ? WispPalette.ink : WispPalette.muted)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             .background(WispPalette.subtlePanelTop, in: Capsule())
         }
     }
@@ -1407,45 +1407,31 @@ private struct SidebarButton: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 12) {
+                Capsule()
+                    .fill(isSelected ? WispPalette.accent : Color.clear)
+                    .frame(width: 3, height: 20)
+
                 Image(systemName: symbolName)
                     .font(.system(size: 14, weight: .semibold))
                     .frame(width: 18)
+                    .foregroundStyle(isSelected ? WispPalette.accent : WispPalette.muted)
                 Text(title)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(isSelected ? .white : WispPalette.ink)
+                    .foregroundStyle(WispPalette.ink)
                 Spacer()
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-            .background(
-                isSelected
-                    ? LinearGradient(
-                        colors: [
-                            WispPalette.accent,
-                            WispPalette.accentStrong
-                        ],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                    : LinearGradient(
-                        colors: [Color.clear, Color.clear],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    ),
-                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-            )
+            .padding(.horizontal, 10)
+            .padding(.vertical, 9)
+            .background(rowBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .stroke(
-                        isSelected ? Color.white.opacity(0.18) : Color.clear,
+                        isSelected ? WispPalette.accent.opacity(0.34) : Color.clear,
                         lineWidth: 1
                     )
             )
-            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .foregroundStyle(isSelected ? .white : .primary)
-            .shadow(color: isSelected || isHovered ? WispPalette.shadow.opacity(0.45) : .clear, radius: 16, x: 0, y: 10)
-            .scaleEffect(isHovered ? 1.01 : 1)
+            .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
         .frame(maxWidth: .infinity)
         .buttonStyle(.plain)
@@ -1454,6 +1440,13 @@ private struct SidebarButton: View {
                 isHovered = hovering
             }
         }
+    }
+
+    private var rowBackground: Color {
+        if isSelected {
+            return WispPalette.accentSoft
+        }
+        return isHovered ? WispPalette.subtlePanelTop : .clear
     }
 }
 

--- a/Sources/MenuBarView.swift
+++ b/Sources/MenuBarView.swift
@@ -6,37 +6,10 @@ struct MenuBarView: View {
     @Bindable var appModel: AppModel
 
     var body: some View {
-        Text(appModel.isDictating ? "Recording" : "Ready")
+        Text(menuStateTitle)
             .foregroundStyle(.secondary)
 
-        Button(appModel.isDictating ? "Stop recording" : "Start recording") {
-            Task {
-                if appModel.isDictating {
-                    await appModel.stopDictation()
-                } else {
-                    await appModel.startDictation()
-                }
-            }
-        }
-
-        Button("Transcribe file…") {
-            Task {
-                await appModel.transcribeFromOpenPanel()
-            }
-        }
-
-        Button("History…") {
-            showMainWindow(selecting: .history)
-        }
-
-        Button("Permissions…") {
-            showMainWindow(selecting: .permissions)
-        }
-
-        Button("Settings…") {
-            showMainWindow(selecting: .settings)
-        }
-        .keyboardShortcut(",", modifiers: [.command])
+        primaryRecordingButton
 
         Divider()
 
@@ -44,23 +17,27 @@ struct MenuBarView: View {
             showMainWindow(selecting: .capture)
         }
 
-        Menu(modelMenuTitle) {
-            if appModel.installedModels.isEmpty {
-                Text("No downloaded models yet")
-            } else {
-                ForEach(appModel.installedModels) { model in
-                    Button(model.displayName) {
-                        appModel.updateSelectedModel(model)
-                    }
-                }
-            }
-
-            Divider()
-
-            Button("Manage models…") {
-                showMainWindow(selecting: .models)
-            }
+        Button("History") {
+            showMainWindow(selecting: .history)
         }
+
+        Button("Clipboard") {
+            showMainWindow(selecting: .clipboard)
+        }
+
+        Button("Settings") {
+            showMainWindow(selecting: .settings)
+        }
+        .keyboardShortcut(",", modifiers: [.command])
+
+        Divider()
+
+        Button("Copy latest transcript") {
+            appModel.copyLatestTranscript()
+        }
+        .disabled(appModel.latestTranscript.isEmpty)
+
+        recentClipsMenu
 
         if !appModel.selectedModelIsInstalled {
             Button("Download default model") {
@@ -68,49 +45,26 @@ struct MenuBarView: View {
                     await appModel.prepareModelIfNeeded()
                 }
             }
-        } else {
-            Button("Show default model in Finder") {
-                appModel.revealModelInFinder()
-            }
-        }
-
-        Button("Open transcript folder") {
-            appModel.revealTranscriptFolder()
         }
 
         Divider()
 
-        Button("Copy transcript") {
-            appModel.copyLatestTranscript()
-        }
-        .disabled(appModel.latestTranscript.isEmpty)
+        MoreMenu(
+            appModel: appModel,
+            modelMenuTitle: modelMenuTitle,
+            showMainWindow: showMainWindow(selecting:)
+        )
 
-        if appModel.clipboardClips.isEmpty {
-            Text("No saved clips")
-                .foregroundStyle(.secondary)
-        } else {
-            Divider()
-
-            Text("Latest clips")
-                .foregroundStyle(.secondary)
-
-            ForEach(Array(appModel.clipboardClips.prefix(5))) { clip in
-                Button(clipMenuTitle(for: clip)) {
-                    appModel.copyClipboardClip(clip)
-                }
-            }
-        }
-
-        Button("Manage clipboard…") {
-            showMainWindow(selecting: .clipboard)
+        Button("Permissions") {
+            showMainWindow(selecting: .permissions)
         }
 
         Divider()
-
-        Text("Sessions: \(appModel.transcriptHistory.count)")
-            .foregroundStyle(.secondary)
 
         Text("Shortcut: \(appModel.hotkey)")
+            .foregroundStyle(.secondary)
+
+        Text("Sessions: \(appModel.transcriptHistory.count)")
             .foregroundStyle(.secondary)
 
         Text("Version 0.1.0")
@@ -120,6 +74,49 @@ struct MenuBarView: View {
             NSApp.terminate(nil)
         }
         .keyboardShortcut("q")
+    }
+
+    private var menuStateTitle: String {
+        switch appModel.workflowState {
+        case .recording:
+            return "Recording"
+        case .transcribing:
+            return "Transcribing"
+        case .failed:
+            return "Needs attention"
+        case .preparing:
+            return "Preparing"
+        case .idle, .ready:
+            return "Ready"
+        }
+    }
+
+    private var primaryRecordingButton: some View {
+        Button(appModel.isDictating ? "Stop recording" : "Start recording") {
+            Task {
+                if appModel.isDictating {
+                    await appModel.stopDictation()
+                } else {
+                    await appModel.startDictation(insertAfterTranscription: true)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var recentClipsMenu: some View {
+        if appModel.clipboardClips.isEmpty {
+            Text("No clips saved")
+                .foregroundStyle(.secondary)
+        } else {
+            Menu("Recent clips") {
+                ForEach(Array(appModel.clipboardClips.prefix(3))) { clip in
+                    Button(clipMenuTitle(for: clip)) {
+                        appModel.copyClipboardClip(clip)
+                    }
+                }
+            }
+        }
     }
 
     private var modelMenuTitle: String {
@@ -151,5 +148,58 @@ struct MenuBarView: View {
         appModel.selectedSidebarItem = item
         openWindow(id: "main")
         NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+private struct MoreMenu: View {
+    @Bindable var appModel: AppModel
+    let modelMenuTitle: String
+    let showMainWindow: (AppModel.SidebarItem) -> Void
+
+    var body: some View {
+        Menu("More") {
+            Button("Transcribe file…") {
+                Task {
+                    await appModel.transcribeFromOpenPanel()
+                }
+            }
+
+            Button("Open transcript folder") {
+                appModel.revealTranscriptFolder()
+            }
+
+            if appModel.selectedModelIsInstalled {
+                Button("Show default model in Finder") {
+                    appModel.revealModelInFinder()
+                }
+            }
+
+            Divider()
+
+            modelMenu
+
+            Button("Manage models…") {
+                showMainWindow(.models)
+            }
+
+            Button("Manage clipboard…") {
+                showMainWindow(.clipboard)
+            }
+        }
+    }
+
+    private var modelMenu: some View {
+        Menu(modelMenuTitle) {
+            if appModel.installedModels.isEmpty {
+                Text("No downloaded models yet")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(appModel.installedModels) { model in
+                    Button(model.displayName) {
+                        appModel.updateSelectedModel(model)
+                    }
+                }
+            }
+        }
     }
 }

--- a/Sources/WispApp.swift
+++ b/Sources/WispApp.swift
@@ -28,14 +28,14 @@ struct WispApp: App {
         }
         .commands {
             CommandGroup(after: .appInfo) {
-                Button("Start Dictation") {
+                Button("Start recording") {
                     Task {
                         await appModel.startDictation()
                     }
                 }
                 .keyboardShortcut("d", modifiers: [.command, .shift])
 
-                Button("Stop Dictation") {
+                Button("Stop recording") {
                     Task {
                         await appModel.stopDictation()
                     }


### PR DESCRIPTION
Stacked on #12. Closes #3

## Summary
- Reorders the menu bar extra into a compact quick menu with Start/Stop first
- Uses menu bar Start recording as an outside-the-app dictation path by inserting after stop
- Moves lower-frequency model/folder utilities into a More menu
- Aligns command-menu copy with Start recording / Stop recording
- Tightens sidebar row sizing and replaces the heavy selected glow with a smaller accent treatment

## Validation
- `./script/build_and_run.sh --build-only`

## Screenshot note
- I attempted a fresh app/menu screenshot after launch, but macOS was at the lock screen and screen capture returned the lock screen instead of Wisp. I did not attach a misleading screenshot.